### PR TITLE
Load CSV data and expose APIs

### DIFF
--- a/src/main/java/com/example/artemis/WebController.java
+++ b/src/main/java/com/example/artemis/WebController.java
@@ -5,6 +5,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.ui.Model;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @Controller
 public class WebController {
 
@@ -24,8 +36,126 @@ public class WebController {
 
     // Neue Seite -> Template (chart.html)
     @GetMapping("/chart")
-    public String chart(Model model) {
+    public String chart(Model model) throws IOException {
         model.addAttribute("title", "Chart Page");
+
+        Map<String, Object> data = loadCsvData();
+        model.addAttribute("idx", data.get("idx"));
+        model.addAttribute("series", data.get("series"));
+
         return "chart"; // sucht templates/chart.html
+    }
+
+    @ResponseBody
+    @GetMapping("/api/drive_style")
+    public List<Map<String, Object>> driveStyle() throws IOException {
+        Path csvPath = Paths.get("Data Base", "fahrtanalyse_daten.csv");
+        List<Double> accel = new ArrayList<>();
+        List<Double> steering = new ArrayList<>();
+
+        try (BufferedReader br = Files.newBufferedReader(csvPath)) {
+            br.readLine(); // header
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] p = line.split(",");
+                if (p.length < 6) continue;
+                accel.add(Double.parseDouble(p[4]));
+                steering.add(Double.parseDouble(p[2]));
+            }
+        }
+
+        double maxAcc = accel.stream().mapToDouble(v -> Math.abs(v)).max().orElse(1.0);
+        double maxSteer = steering.stream().mapToDouble(v -> Math.abs(v)).max().orElse(1.0);
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (int i = 0; i < accel.size(); i++) {
+            double score = (Math.abs(accel.get(i)) / maxAcc + Math.abs(steering.get(i)) / maxSteer) / 2.0;
+            String label;
+            if (score < 0.33) label = "Defensiv";
+            else if (score < 0.66) label = "Normal";
+            else label = "Aggressiv";
+            Map<String, Object> row = new HashMap<>();
+            row.put("index", i);
+            row.put("style", label);
+            row.put("score", Math.round(score * 100.0) / 100.0);
+            result.add(row);
+        }
+
+        return result;
+    }
+
+    @ResponseBody
+    @GetMapping("/api/regression_pairs")
+    public Map<String, Object> regressionPairs() throws IOException {
+        Path jsonPath = Paths.get("Data Base", "fahrtanalyse_regression.json");
+        ObjectMapper mapper = new ObjectMapper();
+        try (BufferedReader br = Files.newBufferedReader(jsonPath)) {
+            return mapper.readValue(br, Map.class);
+        }
+    }
+
+    private Map<String, Object> loadCsvData() throws IOException {
+        Path csvPath = Paths.get("Data Base", "fahrtanalyse_daten.csv");
+
+        List<Integer> idx = new ArrayList<>();
+        List<Double> speed = new ArrayList<>();
+        List<Double> rpm = new ArrayList<>();
+        List<Double> steering = new ArrayList<>();
+        List<Double> distance = new ArrayList<>();
+        List<Double> accel = new ArrayList<>();
+        List<Double> lateralAcc = new ArrayList<>();
+        List<Double> battery = new ArrayList<>();
+        List<Double> distanceFront = new ArrayList<>();
+        List<String> event = new ArrayList<>();
+        List<String> manoeuvre = new ArrayList<>();
+        List<String> terrain = new ArrayList<>();
+        List<String> weather = new ArrayList<>();
+        List<Double> gpsLat = new ArrayList<>();
+        List<Double> gpsLon = new ArrayList<>();
+
+        try (BufferedReader br = Files.newBufferedReader(csvPath)) {
+            String line = br.readLine(); // header
+            int i = 0;
+            while ((line = br.readLine()) != null) {
+                String[] p = line.split(",");
+                if (p.length < 14) continue;
+                speed.add(Double.parseDouble(p[0]));
+                rpm.add(Double.parseDouble(p[1]));
+                steering.add(Double.parseDouble(p[2]));
+                distance.add(Double.parseDouble(p[3]));
+                accel.add(Double.parseDouble(p[4]));
+                lateralAcc.add(Double.parseDouble(p[5]));
+                battery.add(Double.parseDouble(p[6]));
+                distanceFront.add(Double.parseDouble(p[7]));
+                event.add(p[8]);
+                manoeuvre.add(p[9]);
+                terrain.add(p[10]);
+                weather.add(p[11]);
+                gpsLat.add(Double.parseDouble(p[12]));
+                gpsLon.add(Double.parseDouble(p[13]));
+                idx.add(i++);
+            }
+        }
+
+        Map<String, Object> series = new HashMap<>();
+        series.put("speed", speed);
+        series.put("rpm", rpm);
+        series.put("steering", steering);
+        series.put("distance", distance);
+        series.put("accel", accel);
+        series.put("lateral_acc", lateralAcc);
+        series.put("battery", battery);
+        series.put("distance_front", distanceFront);
+        series.put("event", event);
+        series.put("manoeuvre", manoeuvre);
+        series.put("terrain", terrain);
+        series.put("weather", weather);
+        series.put("gps_lat", gpsLat);
+        series.put("gps_lon", gpsLon);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("idx", idx);
+        result.put("series", series);
+        return result;
     }
 }

--- a/src/main/resources/templates/chart.html
+++ b/src/main/resources/templates/chart.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="de">
+<html lang="de" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="utf-8">
   <title>Drive-Data – Fahrtanalyse</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-  <script src="{{ url_for('static', filename='js/Chart.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/chartjs-chart-boxplot.min.js') }}"></script>
+  <script src="/js/chart.min.js"></script>
+  <script src="/js/chartjs-chart-boxplot.min.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-Vt5VgFV+Rrx65gyoAJCrd91B1t8VkK/1yPo3kG09C6M=" crossorigin="">
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-VL3jY32/6PKmspcw1rKQOVrlaRykW0Jge5x7bZL/Icg=" crossorigin=""></script>
   <style>
@@ -102,17 +102,17 @@
     </div>
   </div>
 
-  <script>
-    const labelsFull = {{ idx|tojson|safe }};
-    const sFull = {{ series|tojson|safe }};
+  <script th:inline="javascript">
+    const labelsFull = /*[[${idx}]]*/ [];
+    const sFull = /*[[${series}]]*/ {};
   </script>
-  <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/lorenz.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/drive_style.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/map.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/regression.js') }}"></script>
+  <script src="/js/calculate.js"></script>
+  <script src="/js/boxplot.js"></script>
+  <script src="/js/lorenz.js"></script>
+  <script src="/js/chart.js"></script>
+  <script src="/js/drive_style.js"></script>
+  <script src="/js/map.js"></script>
+  <script src="/js/regression.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', applyRange);
   </script>


### PR DESCRIPTION
## Summary
- Parse driving CSV data and inject it into the chart view
- Provide `/api/drive_style` and `/api/regression_pairs` endpoints
- Update chart template to use Thymeleaf and static resource paths

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c55dc8e58c8331bb2b1ea878208be6