### PR TITLE
feat: add React index page

### DIFF
--- a/src/main/java/com/example/artemis/WebController.java
+++ b/src/main/java/com/example/artemis/WebController.java
@@ -22,16 +22,18 @@ public class WebController {
 
     // Startseite -> Template (index.html)
     @GetMapping("/")
-    public String index(Model model) {
-        model.addAttribute("title", "Artemis Java");
-        return "index"; // sucht templates/index.html
+    public String index() {
+        return "index"; // liefert die React-Startseite
     }
 
     // Beispiel-API Endpoint -> JSON
     @ResponseBody
     @GetMapping("/api/data")
-    public String getData() {
-        return "{ \"status\": \"ok\", \"message\": \"Hello from Spring Boot!\" }";
+    public Map<String, String> getData() {
+        Map<String, String> data = new HashMap<>();
+        data.put("status", "ok");
+        data.put("message", "Hello from Spring Boot!");
+        return data;
     }
 
     // Neue Seite -> Template (chart.html)

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -30,8 +30,8 @@ h1 {
 }
 
 @keyframes fadeInDown {
-  from {opacity: 0; transform: translateY(-20px);} 
-  to {opacity: 1; transform: translateY(0);} 
+  from {opacity: 0; transform: translateY(-20px);}
+  to {opacity: 1; transform: translateY(0);}
 }
 
 .list-group {
@@ -41,6 +41,6 @@ h1 {
 }
 
 @keyframes fadeInUp {
-  from {opacity: 0; transform: translateY(20px);} 
-  to {opacity: 1; transform: translateY(0);} 
+  from {opacity: 0; transform: translateY(20px);}
+  to {opacity: 1; transform: translateY(0);}
 }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'https://esm.sh/react@18';
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+
+function App() {
+  const [message, setMessage] = useState('Daten werden geladen...');
+
+  useEffect(() => {
+    fetch('/api/data')
+      .then((res) => res.json())
+      .then((data) => setMessage(data.message))
+      .catch(() => setMessage('Fehler beim Laden der Daten'));
+  }, []);
+
+  return (
+    <div className="container py-5">
+      <h1>Artemis React Übersicht</h1>
+      <p>{message}</p>
+      <ul className="list-group">
+        <li className="list-group-item"><a href="/chart">Chart Ansicht</a></li>
+        <li className="list-group-item"><a href="/terrain">Terrain/Wetter Daten</a></li>
+        <li className="list-group-item"><a href="/zweidimensionale_analyse.html">Zweidimensionale Analyse</a></li>
+        <li className="list-group-item"><a href="/analyse/drive_style.html">Drive Style Analyse</a></li>
+        <li className="list-group-item"><a href="/trajectory/">Trajektorie Visualisierung</a></li>
+      </ul>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,30 +5,10 @@
   <title>Artemis Übersicht</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-<link rel="stylesheet" href="/css/style.css">
-
+  <link rel="stylesheet" href="/css/style.css">
+  <script type="module" src="/js/app.js"></script>
 </head>
 <body class="text-light">
-  <div class="container py-5">
-    <h1>Artemis HTML Übersicht</h1>
-    <ul class="list-group">
-      <li class="list-group-item">
-        <a href="/chart">Chart Ansicht</a>
-      </li>
-      <li class="list-group-item">
-        <a href="/terrain">Terrain/Wetter Daten</a>
-      </li>
-      <li class="list-group-item">
-        <a href="zweidimensionale_analyse.html">Zweidimensionale Analyse</a>
-      </li>
-      <li class="list-group-item">
-        <a href="analyse/drive_style.html">Drive Style Analyse</a>
-      </li>
-      <li class="list-group-item">
-        <a href="/trajectory/">Trajektorie Visualisierung</a>
-      </li>
-    </ul>
-  </div>
+  <div id="root"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace server-side index template with React-powered page
- fetch `/api/data` on load and display message
- expose JSON API endpoint via controller

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c56ac84f708331b4a0b026678956ce