### PR TITLE
feat: integrate SQLite database

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -1,0 +1,85 @@
+# ARES Fleet Management – Developer Instructions
+
+## Ziel
+Eine Java-Anwendung mit SQLite-Backend und JavaFX-GUI, die folgende Kernobjekte verwaltet:
+
+* **Assets** – Fahrzeuge/Maschinen
+* **Routes** – Routen mit Wegpunkten
+* **Missions** – konkrete Fahrten eines Assets
+* **MissionTasks** – Schritte innerhalb einer Mission
+
+## 1. Setup
+
+1. Repository klonen
+   ```bash
+   git clone https://github.com/<your-org>/ares-fleet.git
+   cd ares-fleet
+   ```
+2. Java-Version (21+)
+   ```bash
+   java -version
+   ```
+3. Maven installieren (falls nötig) – <https://maven.apache.org/install.html>
+4. Projekt builden & starten
+   ```bash
+   mvn clean install
+   mvn exec:java
+   ```
+
+## 2. Projektstruktur
+```
+src/main/java/de/ares/fleet/
+├─ App.java          // Einstiegspunkt JavaFX
+├─ db/Db.java        // SQLite-Connection + Schema-Init
+├─ dao/              // DAO-Klassen (Datenzugriff)
+├─ model/            // Datenmodelle (POJOs)
+└─ ui/               // JavaFX-GUIs (Tabs)
+src/main/resources/
+└─ schema.sql        // Datenbankschema
+```
+
+## 3. Datenbank
+* SQLite-Datei: `~/.ares/ares_fleet.db`
+* Schema beim ersten Start aus `schema.sql`
+* Tabellen: `assets`, `routes`, `route_points`, `missions`, `mission_tasks`, `asset_routes`
+* Views: `view_asset_summary`, `view_route_usage`
+
+## 4. Anforderungen an die GUI
+### Assets-Tab
+* Tabelle: Name, Typ, Status
+* Formular: Neues Asset anlegen (Name, Typ, Hersteller, Seriennummer, Status)
+* CRUD: Create (✓), Read (✓), Update/Delete (optional)
+
+### Routes-Tab
+* Liste aller Routen
+* Detailansicht: RoutePoints (Seq, Lat, Lon, Note)
+* Neue Route + Points hinzufügen
+
+### Missions-Tab
+* Liste aller Missionen (Name, Asset, Status)
+* Detailansicht: MissionTasks anzeigen
+* Neue Mission anlegen (Asset wählen, optional Route)
+* Tasks hinzufügen (Kind + JSON-Params)
+
+## 5. Technische Hinweise
+* DAO-Klassen nutzen `PreparedStatement` und werfen `RuntimeException` bei Fehlern
+* Daten als `ObservableList<>` in JavaFX binden und Tabellen nach Inserts updaten
+* `MissionTask.params` als JSON-String speichern (z. B. Jackson oder org.json)
+
+## 6. Erweiterungen (später)
+* ROS-Export: Missions/Tasks als JSON-Datei
+* Live-Tracking: RoutePoints + Position im GUI (MapView)
+* User-Management: Rechte pro Nutzer
+
+## 7. Qualitätssicherung
+* Unit-Tests für DAOs mit In-Memory-SQLite
+* Smoke-Test der GUI (CRUD für Assets, Routen, Missionen)
+* Dokumentation aktualisieren
+
+## 8. ToDo-Liste
+- [ ] Assets-Tab komplett (CRUD)
+- [ ] Routes mit RoutePoints implementieren
+- [ ] Missions mit MissionTasks umsetzen
+- [ ] ROS-Export vorbereiten
+- [ ] MapView für Live-Tracking integrieren
+- [ ] User-Management hinzufügen

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,13 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+
+        <!-- SQLite JDBC driver -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.46.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/artemis/WebController.java
+++ b/src/main/java/com/example/artemis/WebController.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.artemis.dao.AssetDao;
+import com.example.artemis.model.Asset;
 
 @Controller
 public class WebController {
@@ -105,6 +107,17 @@ public class WebController {
         try (BufferedReader br = Files.newBufferedReader(jsonPath)) {
             return mapper.readValue(br, Map.class);
         }
+    }
+
+    // --- New SQLite-backed endpoints ---
+
+    /**
+     * Returns all assets stored in the SQLite database.
+     */
+    @ResponseBody
+    @GetMapping("/api/assets")
+    public List<Asset> assets() {
+        return new AssetDao().findAll();
     }
 
     private Map<String, Object> loadCsvData() throws IOException {

--- a/src/main/java/com/example/artemis/dao/AssetDao.java
+++ b/src/main/java/com/example/artemis/dao/AssetDao.java
@@ -1,0 +1,55 @@
+package com.example.artemis.dao;
+
+import com.example.artemis.db.Db;
+import com.example.artemis.model.Asset;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Data access object for {@link Asset} records. */
+public class AssetDao {
+
+    /** Returns all assets ordered by name. */
+    public List<Asset> findAll() {
+        List<Asset> out = new ArrayList<>();
+        String sql = "SELECT * FROM assets ORDER BY name";
+        try (Connection c = Db.get();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                Asset a = new Asset();
+                a.id = rs.getInt("id");
+                a.name = rs.getString("name");
+                a.type = rs.getString("type");
+                a.manufacturer = rs.getString("manufacturer");
+                a.serialNumber = rs.getString("serial_number");
+                a.status = rs.getString("status");
+                out.add(a);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return out;
+    }
+
+    /** Inserts the asset and returns it with its generated id. */
+    public Asset insert(Asset a) {
+        String sql = "INSERT INTO assets(name,type,manufacturer,serial_number,status) VALUES(?,?,?,?,?)";
+        try (Connection c = Db.get();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, a.name);
+            ps.setString(2, a.type);
+            ps.setString(3, a.manufacturer);
+            ps.setString(4, a.serialNumber);
+            ps.setString(5, a.status == null ? "active" : a.status);
+            ps.executeUpdate();
+            try (ResultSet keys = ps.getGeneratedKeys()) {
+                if (keys.next()) a.id = keys.getInt(1);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return a;
+    }
+}

--- a/src/main/java/com/example/artemis/db/Db.java
+++ b/src/main/java/com/example/artemis/db/Db.java
@@ -1,0 +1,55 @@
+package com.example.artemis.db;
+
+import java.nio.file.*;
+import java.sql.*;
+import java.util.Scanner;
+
+/**
+ * Provides a singleton SQLite connection and ensures the schema
+ * defined in {@code schema.sql} is created on first access.
+ */
+public class Db {
+    private static Connection INSTANCE;
+
+    /**
+     * Returns the shared database connection. Creates the database file in
+     * {@code ~/.ares/ares_fleet.db} if it does not exist.
+     */
+    public static Connection get() throws SQLException {
+        if (INSTANCE == null || INSTANCE.isClosed()) {
+            Path dbPath = Paths.get(System.getProperty("user.home"), ".ares", "ares_fleet.db");
+            try {
+                Files.createDirectories(dbPath.getParent());
+            } catch (Exception ignore) {}
+            String url = "jdbc:sqlite:" + dbPath;
+            INSTANCE = DriverManager.getConnection(url);
+            try (Statement s = INSTANCE.createStatement()) {
+                s.execute("PRAGMA foreign_keys = ON");
+            }
+            migrateIfEmpty(INSTANCE);
+        }
+        return INSTANCE;
+    }
+
+    private static void migrateIfEmpty(Connection c) {
+        try (Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery("SELECT name FROM sqlite_master WHERE type='table' AND name='assets'")) {
+            if (!rs.next()) {
+                try (var in = Db.class.getResourceAsStream("/schema.sql")) {
+                    if (in == null) throw new IllegalStateException("schema.sql not found");
+                    String ddl = new Scanner(in, "UTF-8").useDelimiter("\\A").next();
+                    for (String stmt : ddl.split(";\\s*\n")) {
+                        String trimmed = stmt.trim();
+                        if (!trimmed.isEmpty()) {
+                            try (Statement st = c.createStatement()) {
+                                st.execute(trimmed);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Migration failed", e);
+        }
+    }
+}

--- a/src/main/java/com/example/artemis/model/Asset.java
+++ b/src/main/java/com/example/artemis/model/Asset.java
@@ -1,0 +1,11 @@
+package com.example.artemis.model;
+
+/** Simple POJO representing an Asset in the fleet database. */
+public class Asset {
+    public Integer id;
+    public String name;
+    public String type;
+    public String manufacturer;
+    public String serialNumber;
+    public String status; // active, inactive, maintenance, retired
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,63 @@
+-- Database schema for ARES Fleet Management
+
+CREATE TABLE assets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    type TEXT,
+    manufacturer TEXT,
+    serial_number TEXT,
+    status TEXT
+);
+
+CREATE TABLE routes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE route_points (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    route_id INTEGER NOT NULL REFERENCES routes(id) ON DELETE CASCADE,
+    seq INTEGER NOT NULL,
+    lat REAL NOT NULL,
+    lon REAL NOT NULL,
+    note TEXT
+);
+
+CREATE TABLE missions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    asset_id INTEGER NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    route_id INTEGER REFERENCES routes(id),
+    status TEXT DEFAULT 'planned',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE mission_tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    mission_id INTEGER NOT NULL REFERENCES missions(id) ON DELETE CASCADE,
+    seq INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    params TEXT
+);
+
+CREATE TABLE asset_routes (
+    asset_id INTEGER NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    route_id INTEGER NOT NULL REFERENCES routes(id) ON DELETE CASCADE,
+    PRIMARY KEY (asset_id, route_id)
+);
+
+CREATE VIEW view_asset_summary AS
+SELECT a.id,
+       a.name,
+       COUNT(m.id) AS missions_count
+FROM assets a
+LEFT JOIN missions m ON m.asset_id = a.id
+GROUP BY a.id;
+
+CREATE VIEW view_route_usage AS
+SELECT r.id,
+       r.name,
+       COUNT(m.id) AS missions_count
+FROM routes r
+LEFT JOIN missions m ON m.route_id = r.id
+GROUP BY r.id;


### PR DESCRIPTION
## Summary
- add SQLite JDBC dependency and schema
- implement Db helper, Asset model and DAO
- expose `/api/assets` endpoint backed by SQLite

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c58da6ff9883319bcc5f12e66d0d2f